### PR TITLE
DT-1333 upgrade to latest spring-boot and replaced deprecated profile …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "1.1.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "1.1.2"
   kotlin("plugin.spring") version "1.4.10"
   kotlin("plugin.jpa") version "1.4.10"
 }
@@ -14,9 +14,9 @@ dependencies {
 
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
-  implementation("org.springdoc:springdoc-openapi-ui:1.4.8")
-  implementation("org.springdoc:springdoc-openapi-data-rest:1.4.8")
-  implementation("org.springdoc:springdoc-openapi-kotlin:1.4.8")
+  implementation("org.springdoc:springdoc-openapi-ui:1.5.0")
+  implementation("org.springdoc:springdoc-openapi-data-rest:1.5.0")
+  implementation("org.springdoc:springdoc-openapi-kotlin:1.5.0")
 
   runtimeOnly("com.h2database:h2:1.4.200")
   runtimeOnly("org.flywaydb:flyway-core:6.5.6")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,10 @@ info.app:
 spring:
   application:
     name: prison-estate
-
+  profiles:
+    group:
+      test:
+        - "dev"
   jpa:
     open-in-view: false
     show-sql: false

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,1 +1,0 @@
-spring.profiles.include: dev


### PR DESCRIPTION
upgrade to latest spring-boot and replaced deprecated profile 

As per spring documentation, profile groups allows you to define a logical name for a related group of profiles. That logical profile name ( group)  then includes all the properties defined in its group member's, along with any properties defined in the profile it self.

In this PR, profile group test includes everything defined in dev profile, plus anything else that could be defined in application-test.yml. This behaviour is similar to what was being offered by profile include, which is now discontinued by spring.
